### PR TITLE
Fix win dll not loading

### DIFF
--- a/TesseractOcrMAUI/ITesseract.cs
+++ b/TesseractOcrMAUI/ITesseract.cs
@@ -16,18 +16,20 @@ public interface ITesseract
 
     /// <summary>
     /// Recognize text from given image. DOES NOT LOAD required TRAINEDDATA!
-    /// This method should not throw.
+    /// <para/>[DEFAUTL_IMPL] Only can throw DllNotFoundException
     /// </summary>
     /// <param name="imagePath">Path to image containing file name and extension.</param>
     /// <returns>RecognizionResult representing status of recognizion, including possible errors.</returns>
+    /// <exception cref="DllNotFoundException">[DEFAUTL_IMPL] If tesseract or any other library is not found.</exception>
     RecognizionResult RecognizeText(string imagePath);
 
     /// <summary>
     /// Load traineddata files from app packages and run recognizion process async.
-    /// This method should not throw.
+    /// <para/>[DEFAUTL_IMPL] Only can throw DllNotFoundException
     /// </summary>
     /// <param name="imagePath">Path to image containing file name and extension.</param>
     /// <returns>Task of RecognizionResult representing status of recognizion, including possible errors.</returns>
+    /// <exception cref="DllNotFoundException">[DEFAUTL_IMPL] If tesseract or any other library is not found.</exception>
     Task<RecognizionResult> RecognizeTextAsync(string imagePath);
 
     /// <summary>

--- a/TesseractOcrMAUI/ImportApis/LeptonicaApi.cs
+++ b/TesseractOcrMAUI/ImportApis/LeptonicaApi.cs
@@ -5,7 +5,7 @@ namespace TesseractOcrMaui.ImportApis;
 internal sealed partial class LeptonicaApi
 {
 #if WINDOWS
-    const string DllName = @"leptonica-1.84.0.dll"; // lib\Windows\x86_64\
+    const string DllName = @"leptonica-1.84.0.dll";
 
 #elif ANDROID21_0_OR_GREATER
     const string DllName = "libleptonica";

--- a/TesseractOcrMAUI/ImportApis/LeptonicaApi.cs
+++ b/TesseractOcrMAUI/ImportApis/LeptonicaApi.cs
@@ -5,7 +5,7 @@ namespace TesseractOcrMaui.ImportApis;
 internal sealed partial class LeptonicaApi
 {
 #if WINDOWS
-    const string DllName = @"lib\Windows\x86_64\leptonica-1.84.0.dll";
+    const string DllName = @"leptonica-1.84.0.dll"; // lib\Windows\x86_64\
 
 #elif ANDROID21_0_OR_GREATER
     const string DllName = "libleptonica";

--- a/TesseractOcrMAUI/ImportApis/TesseractApi.cs
+++ b/TesseractOcrMAUI/ImportApis/TesseractApi.cs
@@ -5,6 +5,8 @@ namespace TesseractOcrMaui.ImportApis;
 internal sealed partial class TesseractApi
 {
 
+    
+
 #if WINDOWS
     const string DllName = @"tesseract53.dll";  // lib\Windows\x86_64\
 #elif ANDROID21_0_OR_GREATER
@@ -12,7 +14,6 @@ internal sealed partial class TesseractApi
 #else
     const string DllName = "Use Windows or Android Platform";
 #endif
-
 
 
     const CharSet StrEncoding = CharSet.Ansi;

--- a/TesseractOcrMAUI/ImportApis/TesseractApi.cs
+++ b/TesseractOcrMAUI/ImportApis/TesseractApi.cs
@@ -8,7 +8,7 @@ internal sealed partial class TesseractApi
     
 
 #if WINDOWS
-    const string DllName = @"tesseract53.dll";  // lib\Windows\x86_64\
+    const string DllName = @"tesseract53.dll";
 #elif ANDROID21_0_OR_GREATER
     const string DllName = "libtesseract";
 #else

--- a/TesseractOcrMAUI/ImportApis/TesseractApi.cs
+++ b/TesseractOcrMAUI/ImportApis/TesseractApi.cs
@@ -4,8 +4,9 @@ namespace TesseractOcrMaui.ImportApis;
 
 internal sealed partial class TesseractApi
 {
+
 #if WINDOWS
-    const string DllName = @"lib\Windows\x86_64\tesseract53.dll";
+    const string DllName = @"tesseract53.dll";  // lib\Windows\x86_64\
 #elif ANDROID21_0_OR_GREATER
     const string DllName = "libtesseract";
 #else

--- a/TesseractOcrMAUI/TessEngine.cs
+++ b/TesseractOcrMAUI/TessEngine.cs
@@ -66,6 +66,7 @@ public class TessEngine : DisposableObject
             Logger.LogError("Cannot initilize '{ctor}' with null trained data path.", nameof(TessEngine));
             throw new ArgumentNullException(nameof(traineddataPath));
         }
+        // Debug: This line throws if dll are not copied to correct folder.
         Handle = new(this, TesseractApi.CreateApi());
         Initialize(languages, traineddataPath, mode, initialOptions);
     }

--- a/TesseractOcrMAUI/Tessdata/TessDataProvider.cs
+++ b/TesseractOcrMAUI/Tessdata/TessDataProvider.cs
@@ -131,7 +131,7 @@ internal class TessDataProvider : ITessDataProvider
         if (File.Exists(destination) && overwritesFiles is false)
         {
             Logger.LogInformation("File '{file}' already exist and '{arg}' is set to false. " +
-                "File will not be copied.", destination, nameof(overwritesFiles));
+                "File will not be copied.", file, nameof(overwritesFiles));
             return (true, "Already exist.");
         }
         if (Path.GetExtension(file) != FileExtension)

--- a/TesseractOcrMAUI/Tesseract.cs
+++ b/TesseractOcrMAUI/Tesseract.cs
@@ -97,12 +97,13 @@ public class Tesseract : ITesseract
     }
 
     /// <summary>
-    /// Recognize text in image. This method should not throw.
+    /// Recognize text in image. This method can only throw DllNotFoundException.
     /// </summary>
     /// <param name="tessDataFolder">Path to folder containing traineddata files.</param>
     /// <param name="traineddataFileNames">Array of traineddata file names, which include .traineddata extension.</param>
     /// <param name="imagePath">Path to image to be recognized with file name and extension.</param>
     /// <returns>RecognizionResult, information about recognizion status</returns>
+    /// <exception cref="DllNotFoundException">If tesseract or any other library is not found.</exception>
     internal RecognizionResult Recognize(string tessDataFolder, string[] traineddataFileNames, string imagePath)
     {
         var (languages, langParseResult) = TrainedDataToLanguage(tessDataFolder, traineddataFileNames);
@@ -202,6 +203,10 @@ public class Tesseract : ITesseract
                 Status = RecognizionStatus.CannotRecognizeText,
                 Message = "Library cannot thresholded image."
             };
+        }
+        catch (DllNotFoundException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/TesseractOcrMAUI/TesseractOcrMaui.csproj
+++ b/TesseractOcrMAUI/TesseractOcrMaui.csproj
@@ -25,7 +25,7 @@
 
 	<!-- Package properties -->
 	<PropertyGroup>
-		<Version>1.0.5.22</Version>
+		<Version>1.0.5.23</Version>
 		<Title>Maui Tesseract ocr</Title>
 		<PackageId>TesseractOcrMaui</PackageId>
 		<Authors>henrivain</Authors>
@@ -76,9 +76,9 @@
 		<AndroidNativeLibrary Include="lib\Android\x86\libtesseract.so" />
 	</ItemGroup>
 
-	<!-- Windows native libraries -->
+	<!-- Windows native libraries to nuget -->
 	<!-- No condition needed, because package path tells to include in windows -->
-	<ItemGroup>
+	<ItemGroup Condition="'$(Configuration)' == 'Release' ">
 		<Resource Include="lib\Windows\x86_64\*.dll" Pack="true" PackagePath="lib\net7.0-windows10.0.19041\">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<PackageCopyToOutput>true</PackageCopyToOutput>
@@ -88,4 +88,14 @@
 	<ItemGroup>
 		<Folder Include="Properties\" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<ContentWithTargetPath Include="lib\Windows\x86_64\**">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>%(Filename)%(Extension)</TargetPath>
+		</ContentWithTargetPath>
+	</ItemGroup>
+	
+	
 </Project>
+

--- a/TesseractOcrMAUI/TesseractOcrMaui.csproj
+++ b/TesseractOcrMAUI/TesseractOcrMaui.csproj
@@ -85,17 +85,18 @@
 		</Resource>
 	</ItemGroup>
 
-	<ItemGroup>
-		<Folder Include="Properties\" />
-	</ItemGroup>
-
-	<ItemGroup>
+	<!-- Copy dlls for debuggin test app -->
+	<!-- Dlls go to output folder, so dll import can find them. -->
+	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<ContentWithTargetPath Include="lib\Windows\x86_64\**">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>
 		</ContentWithTargetPath>
 	</ItemGroup>
-	
+
+	<ItemGroup>
+		<Folder Include="Properties\" />
+	</ItemGroup>
 	
 </Project>
 

--- a/TesseractOcrMAUI/TesseractOcrMaui.csproj
+++ b/TesseractOcrMAUI/TesseractOcrMaui.csproj
@@ -22,10 +22,10 @@
 	<PropertyGroup Condition="'$(Configuration)' == 'Release' ">
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	</PropertyGroup>
-	
+
 	<!-- Package properties -->
 	<PropertyGroup>
-		<Version>1.0.4</Version>
+		<Version>1.0.5.22</Version>
 		<Title>Maui Tesseract ocr</Title>
 		<PackageId>TesseractOcrMaui</PackageId>
 		<Authors>henrivain</Authors>
@@ -47,7 +47,8 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
-	<!-- Nuget includes, only with release mode -->
+
+	<!-- Nuget includes -->
 	<ItemGroup>
 		<None Include="..\README.md" Link="Properties\README.md">
 			<Pack>True</Pack>
@@ -76,28 +77,15 @@
 	</ItemGroup>
 
 	<!-- Windows native libraries -->
-	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-		<None Update="lib\Windows\x86_64\leptonica-1.84.0.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="lib\Windows\x86_64\libpng16.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="lib\Windows\x86_64\tesseract53.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="lib\Windows\x86_64\zlib.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="lib\Windows\x86_64\jpeg62.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="lib\Windows\x86_64\turbojpeg.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+	<!-- No condition needed, because package path tells to include in windows -->
 	<ItemGroup>
-	  <Folder Include="Properties\" />
+		<Resource Include="lib\Windows\x86_64\*.dll" Pack="true" PackagePath="lib\net7.0-windows10.0.19041\">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</Resource>
 	</ItemGroup>
-	
+
+	<ItemGroup>
+		<Folder Include="Properties\" />
+	</ItemGroup>
 </Project>

--- a/TesseractOcrMaui.sln
+++ b/TesseractOcrMaui.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TesseractOcrMaui", "Tessera
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TesseractOcrMauiTestApp", "TesseractOcrMauiTestApp\TesseractOcrMauiTestApp.csproj", "{8EE9586D-E9BA-4FDB-819F-E1D13B80BF05}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{30563E8B-BE16-4EA3-BC54-7B638C023FBD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,5 +28,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {48164EAB-E47E-4B6A-BF12-F77E59C9710D}
 	EndGlobalSection
 EndGlobal

--- a/TesseractOcrMauiTestApp/Platforms/Android/AndroidManifest.xml
+++ b/TesseractOcrMauiTestApp/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" 
+				 android:icon="@mipmap/appicon" 
+				 android:roundIcon="@mipmap/appicon_round"  
+				 android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/TesseractOcrMauiTestApp/Resources/AppIcon/appicon_round.svg
+++ b/TesseractOcrMauiTestApp/Resources/AppIcon/appicon_round.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="456" height="456" fill="#512BD4" />
+</svg>

--- a/TesseractOcrMauiTestApp/TesseractOcrMauiTestApp.csproj
+++ b/TesseractOcrMauiTestApp/TesseractOcrMauiTestApp.csproj
@@ -31,6 +31,10 @@
 
 	<ItemGroup>
 		<!-- App Icon -->
+		<MauiIcon Include="Resources\AppIcon\appicon_round.svg">
+		  <Color>#512BD4</Color>
+		  <ForegroundFile>Resources\AppIcon\appiconfg.svg</ForegroundFile>
+		</MauiIcon>
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
@@ -45,6 +49,10 @@
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Remove="Resources\AppIcon\appicon_round.svg" />
 	</ItemGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
Fixes bug: #8 Nuget package does not copy native libraries to build output on Windows
- Change csproj parameters to pack dll into nuget package.
- Change DllName to "tesseract53.dll" in TesseractApi.cs to point to output dir (Same with leptonica)
- Change windows dlls to be copied to output directory when building project (so works with new DllName)


