### PR TITLE
Add recognizion configuration

### DIFF
--- a/TesseractOcrMAUI/Enums/EnumExtensions.cs
+++ b/TesseractOcrMAUI/Enums/EnumExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace TesseractOcrMaui.Enums;
+
+/// <summary>
+/// Extensions to ease the use of enums and enum statuses..
+/// </summary>
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Check if status is success, notice that even if this is false, state might be still not failed. (See <see cref="SuccessOrInProgress(RecognizionStatus)"/>)
+    /// </summary>
+    /// <param name="status"></param>
+    /// <returns>True if success, otherwise false.</returns>
+    public static bool FinishedWithSuccess(this RecognizionStatus status) => status is RecognizionStatus.Success;
+
+    /// <summary>
+    /// Check if status is not success.
+    /// </summary>
+    /// <param name="status"></param>
+    /// <returns>True if ussuccessful, otherwise false.</returns>
+    public static bool NotSuccess(this RecognizionStatus status) => FinishedWithSuccess(status) is false
+        && status is RecognizionStatus.InProgressSuccess is false;
+
+    /// <summary>
+    /// Check if status is "not failed".
+    /// </summary>
+    /// <param name="status"></param>
+    /// <returns>True if ussuccessful, otherwise false.</returns>
+    public static bool SuccessOrInProgress(this RecognizionStatus status) =>
+        status is RecognizionStatus.Success or RecognizionStatus.InProgressSuccess;
+
+
+}

--- a/TesseractOcrMAUI/Exceptions/KnownIssueException.cs
+++ b/TesseractOcrMAUI/Exceptions/KnownIssueException.cs
@@ -1,0 +1,38 @@
+﻿namespace TesseractOcrMaui.Exceptions;
+
+/// <summary>
+/// Exception thrown when known error throws exception 
+/// </summary>
+public class KnownIssueException : LeptonicaException
+{
+    /// <summary>
+    /// New exception thrown when known error throws exception
+    /// </summary>
+    public KnownIssueException() { }
+
+    /// <summary>
+    /// New exception thrown when known error throws exception
+    /// </summary>
+    /// <param name="message"></param>
+    public KnownIssueException(string message) : base(message) { }
+
+    /// <summary>
+    /// New exception thrown when known error throws exception
+    /// </summary>
+    /// <param name="message">Error reason.</param>
+    /// <param name="innerException">Exception that caused this error.</param>
+    public KnownIssueException(string message, Exception innerException) 
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Information how to find information about issue
+    /// </summary>
+    public required string IssueInformation { get; set; }
+
+    /// <summary>
+    /// Link to Issue in internet
+    /// </summary>
+    public string? ReferringLink { get; set; }
+}

--- a/TesseractOcrMAUI/Exceptions/LeptonicaException.cs
+++ b/TesseractOcrMAUI/Exceptions/LeptonicaException.cs
@@ -1,21 +1,42 @@
 ﻿using System.Runtime.Serialization;
 
 namespace TesseractOcrMaui.Exceptions;
+
+/// <summary>
+/// Exception that Leptonica might throw when error occurs
+/// </summary>
 [Serializable]
-internal class LeptonicaException : Exception
+public class LeptonicaException : Exception
 {
+    /// <summary>
+    /// New Exception that Leptonica might throw when error occurs
+    /// </summary>
     public LeptonicaException()
     {
     }
 
+    /// <summary>
+    /// New Exception that Leptonica might throw when error occurs
+    /// </summary>
+    /// <param name="message"></param>
     public LeptonicaException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// New Exception that Leptonica might throw when error occurs
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="innerException"></param>
     public LeptonicaException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// New Exception that Leptonica might throw when error occurs
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="info"></param>
     protected LeptonicaException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }

--- a/TesseractOcrMAUI/ITessEngineConfigurable.cs
+++ b/TesseractOcrMAUI/ITessEngineConfigurable.cs
@@ -1,0 +1,21 @@
+﻿namespace TesseractOcrMaui;
+
+/// <summary>
+/// Interface that give access to certain TessEngine properties
+/// </summary>
+public interface ITessEngineConfigurable
+{
+    /// <summary>
+    /// Set PageSegmentationMode that is used if no other mode 
+    /// is passed in method parameters.
+    /// </summary>
+    PageSegmentationMode DefaultSegmentationMode { set; }
+
+    /// <summary>
+    /// Set tesseract engine variable by its name and string value.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="value"></param>
+    /// <returns>True if success, otherwise false.</returns>
+    bool SetVariable(string name, string value);
+}

--- a/TesseractOcrMAUI/ITesseract.cs
+++ b/TesseractOcrMAUI/ITesseract.cs
@@ -68,9 +68,21 @@ public interface ITesseract
     Task<RecognizionResult> RecognizeTextAsync(Pix image);
 
     /// <summary>
+    /// Try to get Tesseract library version 
+    /// </summary>
+    /// <returns>string representation of version if version available, otherwise null</returns>
+    string? TryGetTesseractLibVersion();
+
+    /// <summary>
     /// Folder where tessdata should be stored. 
     /// Provided by ITessDataProvider. 
     /// Load with LoadTraineddataAsync();
     /// </summary>
     string TessDataFolder { get; }
+
+    /// <summary>
+    /// Action to configure TessEngine used in recognizion. This action is run just before recognizion.
+    /// </summary>
+    Action<TessEngine>? EngineConfiguration { get; set; }
+
 }

--- a/TesseractOcrMAUI/ITesseract.cs
+++ b/TesseractOcrMAUI/ITesseract.cs
@@ -83,6 +83,6 @@ public interface ITesseract
     /// <summary>
     /// Action to configure TessEngine used in recognizion. This action is run just before recognizion.
     /// </summary>
-    Action<TessEngine>? EngineConfiguration { get; set; }
+    Action<ITessEngineConfigurable>? EngineConfiguration { get; set; }
 
 }

--- a/TesseractOcrMAUI/ITesseract.cs
+++ b/TesseractOcrMAUI/ITesseract.cs
@@ -83,6 +83,6 @@ public interface ITesseract
     /// <summary>
     /// Action to configure TessEngine used in recognizion. This action is run just before recognizion.
     /// </summary>
-    Action<ITessEngineConfigurable>? EngineConfiguration { get; set; }
+    Action<ITessEngineConfigurable>? EngineConfiguration { set; }
 
 }

--- a/TesseractOcrMAUI/Imaging/ImageHelpers.cs
+++ b/TesseractOcrMAUI/Imaging/ImageHelpers.cs
@@ -1,0 +1,17 @@
+﻿namespace TesseractOcrMaui.Imaging;
+internal static class ImageHelpers
+{
+    internal static bool IsJpeg(in byte[] imageBytes)
+    {
+        byte first = imageBytes[0];
+        byte second = imageBytes[1];
+        byte secondToLast = imageBytes[^2];
+        byte last = imageBytes[^1];
+
+        return imageBytes.Length > 4
+            && first is 0xFF
+            && second is 0xD8
+            && secondToLast is 0xFF
+            && last is 0xD9;
+    }
+}

--- a/TesseractOcrMAUI/Pix.cs
+++ b/TesseractOcrMAUI/Pix.cs
@@ -169,6 +169,7 @@ public unsafe sealed class Pix : DisposableObject, IEquatable<Pix>
     /// <param name="bytes"></param>
     /// <returns>New pix representing loaded memory.</returns>
     /// <exception cref="IOException">If image cannot be loaded from memory.</exception>
+    /// <exception cref="KnownIssueException">If image cannot be loaded from memory on Android and image is in jpeg format.</exception>
     public static Pix LoadFromMemory(byte[] bytes)
     {
         IntPtr handle;
@@ -178,6 +179,16 @@ public unsafe sealed class Pix : DisposableObject, IEquatable<Pix>
         }
         if (handle == IntPtr.Zero)
         {
+#if ANDROID
+            if (ImageHelpers.IsJpeg(bytes))
+            {
+                throw new KnownIssueException("Failed to load image from memory, this is a known issue.")
+                {
+                    IssueInformation = "TesseractOcrMaui Issue #17",
+                    ReferringLink = "https://github.com/henrivain/TesseractOcrMaui/issues/17",
+                };
+            }
+#endif
             throw new IOException("Failed to load image from memory.");
         }
         return new(handle);

--- a/TesseractOcrMAUI/Pix.cs
+++ b/TesseractOcrMAUI/Pix.cs
@@ -186,6 +186,7 @@ public unsafe sealed class Pix : DisposableObject, IEquatable<Pix>
                 {
                     IssueInformation = "TesseractOcrMaui Issue #17",
                     ReferringLink = "https://github.com/henrivain/TesseractOcrMaui/issues/17",
+                    HelpLink = "https://github.com/henrivain/TesseractOcrMaui/issues/17"
                 };
             }
 #endif

--- a/TesseractOcrMAUI/Results/ResultExtensions.cs
+++ b/TesseractOcrMAUI/Results/ResultExtensions.cs
@@ -1,9 +1,8 @@
-﻿using TesseractOcrMaui.Results;
+﻿using System.Diagnostics;
+using TesseractOcrMaui.Results;
 using TesseractOcrMaui.Tessdata;
-using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 
-namespace TesseractOcrMaui.Extensions;
+namespace TesseractOcrMaui.Results;
 
 /// <summary>
 /// Extensions to ease the use of enums and enum statuses..
@@ -13,28 +12,6 @@ public static class ResultExtensions
 
 
 
-    /// <summary>
-    /// Check if status is success, notice that even if this is false, state might be still not failed. (See <see cref="SuccessOrInProgress(RecognizionStatus)"/>)
-    /// </summary>
-    /// <param name="status"></param>
-    /// <returns>True if success, otherwise false.</returns>
-    public static bool FinishedWithSuccess(this RecognizionStatus status) => status is RecognizionStatus.Success;
-
-    /// <summary>
-    /// Check if status is not success.
-    /// </summary>
-    /// <param name="status"></param>
-    /// <returns>True if ussuccessful, otherwise false.</returns>
-    public static bool NotSuccess(this RecognizionStatus status) => FinishedWithSuccess(status) is false 
-        && status is RecognizionStatus.InProgressSuccess is false;
-
-    /// <summary>
-    /// Check if status is "not failed".
-    /// </summary>
-    /// <param name="status"></param>
-    /// <returns>True if ussuccessful, otherwise false.</returns>
-    public static bool SuccessOrInProgress(this RecognizionStatus status) => 
-        status is RecognizionStatus.Success or RecognizionStatus.InProgressSuccess;
 
 
     /// <summary>
@@ -51,19 +28,6 @@ public static class ResultExtensions
     /// <returns>True if ussuccessful, otherwise false.</returns>
     public static bool NotSuccess(this RecognizionResult result) => result.Status.NotSuccess();
 
-    /// <summary>
-    /// Check if state is success.
-    /// </summary>
-    /// <param name="state"></param>
-    /// <returns>True if success, otherwise false.</returns>
-    public static bool FinishedWithSuccess(this TessDataState state) => state is TessDataState.AllValid or TessDataState.AtLeastOneValid;
-
-    /// <summary>
-    /// Check if state is not success.
-    /// </summary>
-    /// <param name="state"></param>
-    /// <returns>True if not successful, otherwise false.</returns>
-    public static bool NotSuccess(this TessDataState state) => state.FinishedWithSuccess() is false;
 
     /// <summary>
     /// Check if result has success code.
@@ -132,7 +96,7 @@ public static class ResultExtensions
                 $"'{nameof(ResultExtensions)}.{nameof(LogLoadErrorsIfNotAllSuccess)}'.");
             return;
         }
-        if (result.NotSuccess() || result.InvalidFiles?.Length > 0) 
+        if (result.NotSuccess() || result.InvalidFiles?.Length > 0)
         {
             var statusStr = result.FinishedWithSuccess() ? "all" : "any";
             logger.LogWarning("Could not load {any/all} traineddata files, '{count}' files failed.",

--- a/TesseractOcrMAUI/Results/ResultExtensions.cs
+++ b/TesseractOcrMAUI/Results/ResultExtensions.cs
@@ -9,11 +9,6 @@ namespace TesseractOcrMaui.Results;
 /// </summary>
 public static class ResultExtensions
 {
-
-
-
-
-
     /// <summary>
     /// Check if result has success code.
     /// </summary>

--- a/TesseractOcrMAUI/TessEngine.cs
+++ b/TesseractOcrMAUI/TessEngine.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using TesseractOcrMaui.ImportApis;
+﻿using TesseractOcrMaui.ImportApis;
 
 
 namespace TesseractOcrMaui;
@@ -7,7 +6,7 @@ namespace TesseractOcrMaui;
 /// <summary>
 /// Tesseract engine that can process images with native library bindings.
 /// </summary>
-public class TessEngine : DisposableObject
+public class TessEngine : DisposableObject, ITessEngineConfigurable
 {
     /// <summary>
     /// Create new Tess engine with native Tesseract api.
@@ -75,11 +74,9 @@ public class TessEngine : DisposableObject
     /// <summary>
     /// Handle to used Tesseract api.
     /// </summary>
-    public HandleRef Handle { get; private set; }
+    internal HandleRef Handle { get; private set; }
 
-    /// <summary>
-    /// Segmentation Mode that tesseract uses if nothing else is provided.
-    /// </summary>
+    /// <inheritdoc/>
     public PageSegmentationMode DefaultSegmentationMode { get; set; } = PageSegmentationMode.Auto;
 
     /// <summary>
@@ -157,17 +154,19 @@ public class TessEngine : DisposableObject
     /// <returns>True if success, otherwise false.</returns>
     public bool SetDebugVariable(string name, string value)
     {
-        return TesseractApi.SetDebugVariable(Handle, name, value) is not 0;
+        bool success = TesseractApi.SetDebugVariable(Handle, name, value) is not 0;
+        Logger.LogInformation("Set Tesseract DEBUG variable '{name}' to value '{value}', success {success}",
+            name, value, success);
+        return success;
     }
-    /// <summary>
-    /// Set tesseract library variable.
-    /// </summary>
-    /// <param name="name"></param>
-    /// <param name="value"></param>
-    /// <returns>True if success, otherwise false.</returns>
+    
+    /// <inheritdoc/>
     public bool SetVariable(string name, string value)
     {
-        return TesseractApi.SetVariable(Handle, name, value) is not 0;
+        bool success = TesseractApi.SetVariable(Handle, name, value) is not 0;
+        Logger.LogInformation("Set Tesseract variable '{name}' to value '{value}', success {success}",
+            name, value, success);
+        return success;
     }
 
     /// <summary>

--- a/TesseractOcrMAUI/TessEngine.cs
+++ b/TesseractOcrMAUI/TessEngine.cs
@@ -83,9 +83,11 @@ public class TessEngine : DisposableObject
     public PageSegmentationMode DefaultSegmentationMode { get; set; } = PageSegmentationMode.Auto;
 
     /// <summary>
-    /// Version of used Tesseract api. Returns empty string if version cannot be optained.
+    /// Version of used Tesseract api. Returns null if version cannot be obtained.
     /// </summary>
-    public static string Version => Marshal.PtrToStringAnsi(TesseractApi.GetVersion()) ?? string.Empty;
+    /// <returns>Version string if successful, otherwise null</returns>
+    public static string? TryGetVersion() 
+        => Marshal.PtrToStringAnsi(TesseractApi.GetVersion());
 
 
     /// <summary>

--- a/TesseractOcrMAUI/TessEngineExtensions.cs
+++ b/TesseractOcrMAUI/TessEngineExtensions.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace TesseractOcrMaui;
+
+/// <summary>
+/// Extensions to help engine configuration
+/// </summary>
+public static class TessEngineExtensions
+{
+    /// <summary>
+    /// Configure characters that ocr can use.
+    /// </summary>
+    /// <param name="engine">Engine to be configured.</param>
+    /// <param name="allowedCharacters">Characters that ocr can recognize. Null or empty string means all characters.</param>
+    public static void SetCharacterWhitelist(this TessEngine engine, string? allowedCharacters)
+    {
+        engine.SetVariable("tessedit_char_whitelist", allowedCharacters ?? "");
+    }
+
+    /// <summary>
+    /// Configure characters that ocr can use.
+    /// </summary>
+    /// <param name="engine">Engine to be configured.</param>
+    /// <param name="blockedLetters">Characters that ocr cannot recognize.</param>
+    public static void SetCharacterBlacklist(this TessEngine engine, string? blockedLetters)
+    {
+        engine.SetVariable("tessedit_char_whitelist", blockedLetters ?? "");
+    }
+
+    /// <summary>
+    /// Configure engine mode that ocr uses
+    /// </summary>
+    /// <param name="engine">Engine to be configured.</param>
+    /// <param name="engineMode">PageSegmentationMode that defines how ocr tries to find characters.</param>
+    public static void SetEngineMode(this TessEngine engine, PageSegmentationMode engineMode)
+    {
+        engine.DefaultSegmentationMode = engineMode;
+    }
+
+
+}

--- a/TesseractOcrMAUI/TessEngineExtensions.cs
+++ b/TesseractOcrMAUI/TessEngineExtensions.cs
@@ -12,30 +12,18 @@ public static class TessEngineExtensions
     /// </summary>
     /// <param name="engine">Engine to be configured.</param>
     /// <param name="allowedCharacters">Characters that ocr can recognize. Null or empty string means all characters.</param>
-    public static void SetCharacterWhitelist(this TessEngine engine, string? allowedCharacters)
+    public static bool SetCharacterWhitelist(this ITessEngineConfigurable engine, string? allowedCharacters)
     {
-        engine.SetVariable("tessedit_char_whitelist", allowedCharacters ?? "");
+        return engine.SetVariable("tessedit_char_whitelist", allowedCharacters ?? "");
     }
 
     /// <summary>
-    /// Configure characters that ocr can use.
+    /// Configure characters that ocr cannot use.
     /// </summary>
     /// <param name="engine">Engine to be configured.</param>
-    /// <param name="blockedLetters">Characters that ocr cannot recognize.</param>
-    public static void SetCharacterBlacklist(this TessEngine engine, string? blockedLetters)
+    /// <param name="blacklistedCharacters">Characters that ocr cannot recognize.</param>
+    public static bool SetCharacterBlacklist(this ITessEngineConfigurable engine, string? blacklistedCharacters)
     {
-        engine.SetVariable("tessedit_char_whitelist", blockedLetters ?? "");
+        return engine.SetVariable("tessedit_char_blacklist", blacklistedCharacters ?? "");
     }
-
-    /// <summary>
-    /// Configure engine mode that ocr uses
-    /// </summary>
-    /// <param name="engine">Engine to be configured.</param>
-    /// <param name="engineMode">PageSegmentationMode that defines how ocr tries to find characters.</param>
-    public static void SetEngineMode(this TessEngine engine, PageSegmentationMode engineMode)
-    {
-        engine.DefaultSegmentationMode = engineMode;
-    }
-
-
 }

--- a/TesseractOcrMAUI/Tessdata/TessDataExtensions.cs
+++ b/TesseractOcrMAUI/Tessdata/TessDataExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace TesseractOcrMaui.Tessdata;
+
+/// <summary>
+/// Extensions to convert TessDataState to success boolean
+/// </summary>
+public static class TessDataExtensions
+{
+    /// <summary>
+    /// Check if state is success.
+    /// </summary>
+    /// <param name="state"></param>
+    /// <returns>True if success, otherwise false.</returns>
+    public static bool FinishedWithSuccess(this TessDataState state) 
+        => state is TessDataState.AllValid or TessDataState.AtLeastOneValid;
+
+    /// <summary>
+    /// Check if state is not success.
+    /// </summary>
+    /// <param name="state"></param>
+    /// <returns>True if not successful, otherwise false.</returns>
+    public static bool NotSuccess(this TessDataState state) => state.FinishedWithSuccess() is false;
+}

--- a/TesseractOcrMAUI/Tesseract.cs
+++ b/TesseractOcrMAUI/Tesseract.cs
@@ -54,6 +54,10 @@ public class Tesseract : ITesseract
     /// <inheritdoc/>
     public string TessDataFolder => TessDataProvider.TessDataFolder;
 
+    /// <inheritdoc/>
+    public Action<TessEngine>? EngineConfiguration { get; set; }
+
+
     ITessDataProvider TessDataProvider { get; }
     ILogger<ITesseract> Logger { get; }
 
@@ -176,10 +180,19 @@ public class Tesseract : ITesseract
         catch (IOException)
         {
             Logger.LogInformation("Cannot load pix from memory. Make sure your image is in right format.");
-            return new()
+            return new RecognizionResult
             {
                 Status = RecognizionStatus.InvalidImage,
-                Message = "Invalid image, cannot be loaded"
+                Message = "Invalid image, cannot be loaded",
+            };
+        }
+        catch (KnownIssueException ex) 
+        {
+            Logger.LogWarning("Cannot load pix from memory. '{ex}'", ex);
+            return new RecognizionResult
+            {
+                Status = RecognizionStatus.InvalidImage,
+                Message = $"Cannot load pix from memory. (This is a known issue, see '{ex.HelpLink}'.)"
             };
         }
     }
@@ -199,7 +212,6 @@ public class Tesseract : ITesseract
 
 
     
-
     internal RecognizionResult Recognize(Pix pix, string tessDataFolder, string[] traineddataFileNames)
     {
         var (status, languages) = TrainedDataToLanguage(tessDataFolder, traineddataFileNames);
@@ -240,6 +252,12 @@ public class Tesseract : ITesseract
         {
             // nulls are alredy checked, can't throw.
             using var engine = new TessEngine(languages, tessDataFolder, Logger);
+
+            if (EngineConfiguration is not null)
+            {
+                EngineConfiguration(engine);
+            }
+
             using var page = engine.ProcessImage(pix);
 
             // SegMode can't be OsdOnly in here.
@@ -312,6 +330,7 @@ public class Tesseract : ITesseract
                 Message = $"Failed to ocr for unknown reason '{ex.GetType().Name}': '{ex.Message}'."
             };
         }
+       
 
         Logger.LogInformation("Recognized image with confidence '{value}'", confidence);
         Logger.LogInformation("Image contained text with length '{value}'", text?.Length ?? 0);
@@ -384,5 +403,5 @@ public class Tesseract : ITesseract
         return (RecognizionStatus.InProgressSuccess, string.Join('+', languages));
     }
 
-
+    public string? TryGetTesseractLibVersion() => TessEngine.TryGetVersion();
 }

--- a/TesseractOcrMAUI/Tesseract.cs
+++ b/TesseractOcrMAUI/Tesseract.cs
@@ -55,7 +55,7 @@ public class Tesseract : ITesseract
     public string TessDataFolder => TessDataProvider.TessDataFolder;
 
     /// <inheritdoc/>
-    public Action<TessEngine>? EngineConfiguration { get; set; }
+    public Action<ITessEngineConfigurable>? EngineConfiguration { get; set; }
 
 
     ITessDataProvider TessDataProvider { get; }
@@ -69,8 +69,6 @@ public class Tesseract : ITesseract
         return result;
     }
 
-
-    
     /// <inheritdoc/>
     public RecognizionResult RecognizeText(string imagePath)
     {

--- a/TesseractOcrMAUI/Tesseract.cs
+++ b/TesseractOcrMAUI/Tesseract.cs
@@ -112,10 +112,19 @@ public class Tesseract : ITesseract
         catch (IOException)
         {
             Logger.LogInformation("Cannot load pix from memory. Make sure your image is in right format.");
-            return new()
+            return new RecognizionResult
             {
                 Status = RecognizionStatus.InvalidImage,
-                Message = "Invalid image, cannot be loaded"
+                Message = "Invalid image, cannot be loaded",
+            };
+        }
+        catch (KnownIssueException ex)
+        {
+            Logger.LogWarning("Cannot load pix from memory. '{ex}'", ex);
+            return new RecognizionResult
+            {
+                Status = RecognizionStatus.InvalidImage,
+                Message = $"Cannot load pix from memory. (This is a known issue, see '{ex.HelpLink}'.)"
             };
         }
     }
@@ -192,7 +201,7 @@ public class Tesseract : ITesseract
             return new RecognizionResult
             {
                 Status = RecognizionStatus.InvalidImage,
-                Message = $"Cannot load pix from memory. (This is a known issue, see '{ex.HelpLink}'.)"
+                Message = $"Cannot load pix from memory. (This is a known issue, see '{ex.ReferringLink}'.)"
             };
         }
     }
@@ -403,5 +412,6 @@ public class Tesseract : ITesseract
         return (RecognizionStatus.InProgressSuccess, string.Join('+', languages));
     }
 
+    /// <inheritdoc/>
     public string? TryGetTesseractLibVersion() => TessEngine.TryGetVersion();
 }

--- a/TesseractOcrMAUI/Usings.cs
+++ b/TesseractOcrMAUI/Usings.cs
@@ -1,6 +1,5 @@
 ﻿global using TesseractOcrMaui.Enums;
 global using TesseractOcrMaui.Exceptions;
-global using TesseractOcrMaui.Extensions;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Logging.Abstractions;
 global using System.Runtime.InteropServices;

--- a/TesseractOcrMauiTestApp/MainPage.xaml
+++ b/TesseractOcrMauiTestApp/MainPage.xaml
@@ -51,14 +51,19 @@
 
 
 
-                        <HorizontalStackLayout HorizontalOptions="Center">
-                            <Button Text="Recognize as image"
-                                    HorizontalOptions="Center"
-                                    Clicked="DEMO_Recognize_AsImage" />
-                            <Button Text="Recognize as bytes"
-                                    HorizontalOptions="Center"
-                                    Clicked="DEMO_Recognize_AsBytes" />
-                        </HorizontalStackLayout>
+                        <ScrollView Orientation="{OnPlatform Android=Horizontal, Default=Neither}">
+                            <HorizontalStackLayout HorizontalOptions="Center">
+                                <Button Text="Recognize as image"
+                                        HorizontalOptions="Center"
+                                        Clicked="DEMO_Recognize_AsImage" />
+                                <Button Text="Recognize as bytes"
+                                        HorizontalOptions="Center"
+                                        Clicked="DEMO_Recognize_AsBytes" />
+                                <Button Text="Recognize configured"
+                                        HorizontalOptions="Center"
+                                        Clicked="DEMO_Recognize_AsConfigured" />
+                            </HorizontalStackLayout>
+                        </ScrollView>
                     </VerticalStackLayout>
                 </Border>
             </VerticalStackLayout>

--- a/TesseractOcrMauiTestApp/MainPage.xaml
+++ b/TesseractOcrMauiTestApp/MainPage.xaml
@@ -4,56 +4,66 @@
              x:Class="TesseractOcrMauiTestApp.MainPage">
 
     <ScrollView>
-        <VerticalStackLayout Spacing="25"
-                             Padding="30,0"
-                             VerticalOptions="Center">
-
-            <Image Source="dotnet_bot.png"
-                   SemanticProperties.Description="Cute dot net bot waving hi to you!"
-                   HeightRequest="200"
-                   HorizontalOptions="Center" />
-
-            <Label Text="Hello, World!"
-                   SemanticProperties.HeadingLevel="Level1"
-                   FontSize="32"
-                   HorizontalOptions="Center" />
-
-            <Label Text="Welcome to .NET Multi-platform App UI"
-                   SemanticProperties.HeadingLevel="Level2"
-                   SemanticProperties.Description="Welcome to dot net Multi platform App U I"
-                   FontSize="18"
-                   HorizontalOptions="Center" />
+        <Grid>
+            <Button Text="GetVersion"
+                    HorizontalOptions="End"
+                    VerticalOptions="Start"
+                    Margin="20" 
+                    Clicked="DEMO_GetVersion"
+                    />
+            <VerticalStackLayout Spacing="25"
+                                 Padding="30,0"
+                                 VerticalOptions="Center">
 
 
+                <Image Source="dotnet_bot.png"
+                       SemanticProperties.Description="Cute dot net bot waving hi to you!"
+                       HeightRequest="200"
+                       HorizontalOptions="Center" />
 
-            <Border>
-                <VerticalStackLayout HorizontalOptions="Center">
-                    <Label x:Name="confidenceLabel"
-                           HorizontalTextAlignment="Center"
-                           Text="Confidence: -1" />
-                    <Label Text="Recognized text"
-                           HorizontalTextAlignment="Center" />
-                    <Label x:Name="fileModeLabel"
-                           Text="-"
-                           HorizontalTextAlignment="Center" 
-                           Margin="0,0,0,50"/>
-                    <Label x:Name="resultLabel"
-                           Text="Nothing yet"
-                           HorizontalTextAlignment="Center" />
+                <Label Text="Hello, World!"
+                       SemanticProperties.HeadingLevel="Level1"
+                       FontSize="32"
+                       HorizontalOptions="Center" />
 
-            
+                <Label Text="Welcome to .NET Multi-platform App UI"
+                       SemanticProperties.HeadingLevel="Level2"
+                       SemanticProperties.Description="Welcome to dot net Multi platform App U I"
+                       FontSize="18"
+                       HorizontalOptions="Center" />
 
-                    <HorizontalStackLayout HorizontalOptions="Center">
-                        <Button Text="Recognize as image"
-                                HorizontalOptions="Center"
-                                Clicked="DEMO_Recognize_AsImage" />
-                        <Button Text="Recognize as bytes"
-                                HorizontalOptions="Center"
-                                Clicked="DEMO_Recognize_AsBytes" />
-                    </HorizontalStackLayout>
-                </VerticalStackLayout>
-            </Border>
-        </VerticalStackLayout>
+
+
+                <Border>
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label x:Name="confidenceLabel"
+                               HorizontalTextAlignment="Center"
+                               Text="Confidence: -1" />
+                        <Label Text="Recognized text"
+                               HorizontalTextAlignment="Center" />
+                        <Label x:Name="fileModeLabel"
+                               Text="-"
+                               HorizontalTextAlignment="Center"
+                               Margin="0,0,0,50" />
+                        <Label x:Name="resultLabel"
+                               Text="Nothing yet"
+                               HorizontalTextAlignment="Center" />
+
+
+
+                        <HorizontalStackLayout HorizontalOptions="Center">
+                            <Button Text="Recognize as image"
+                                    HorizontalOptions="Center"
+                                    Clicked="DEMO_Recognize_AsImage" />
+                            <Button Text="Recognize as bytes"
+                                    HorizontalOptions="Center"
+                                    Clicked="DEMO_Recognize_AsBytes" />
+                        </HorizontalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+
+        </Grid>
     </ScrollView>
 
 </ContentPage>

--- a/TesseractOcrMauiTestApp/MainPage.xaml.cs
+++ b/TesseractOcrMauiTestApp/MainPage.xaml.cs
@@ -31,19 +31,9 @@ public partial class MainPage : ContentPage
 
         // Recognize image 
         var result = await Tesseract.RecognizeTextAsync(path);
-
-
         
-        // Give output (Not important)
-        fileModeLabel.Text = $"File mode: FromPath";
-        if (result.NotSuccess())
-        {
-            confidenceLabel.Text = $"Confidence: -1";
-            resultLabel.Text = $"Recognizion failed: {result.Status}";
-            return;
-        }
-        confidenceLabel.Text = $"Confidence: {result.Confidence}";
-        resultLabel.Text = result.RecognisedText;
+        // Show output (Not important)
+        ShowOutput("FromPath", result);
     }
 
     private async void DEMO_Recognize_AsBytes(object sender, EventArgs e)
@@ -64,23 +54,50 @@ public partial class MainPage : ContentPage
         var result = await Tesseract.RecognizeTextAsync(buffer);
         
         
-        // Give output (Not important)
-        fileModeLabel.Text = $"File mode: FromBytes";
-        if (result.NotSuccess())
+        // Show output (Not important)
+        ShowOutput("FromBytes", result);
+    }
+
+    private async void DEMO_Recognize_AsConfigured(object sender, EventArgs e)
+    {
+        // Select image (Not important)
+        var path = await GetUserSelectedPath();
+        if (path is null)
         {
-            confidenceLabel.Text = $"Confidence: -1";
-            resultLabel.Text = $"Recognizion failed: {result.Status}";
             return;
         }
-        confidenceLabel.Text = $"Confidence: {result.Confidence}";
-        resultLabel.Text = result.RecognisedText;
+
+        Tesseract.EngineConfiguration = (engine) =>
+        {
+            // Engine uses DefaultSegmentationMode, if no other is passed as method parameter.
+            // If ITesseract is injected to page, this is only way of setting PageSegmentationMode.
+            // PageSegmentationMode defines how ocr tries to look for text, for example singe character or single word.
+            // By default uses PageSegmentationMode.Auto.
+            engine.DefaultSegmentationMode = TesseractOcrMaui.Enums.PageSegmentationMode.Auto;
+            
+            engine.SetCharacterWhitelist("abcdefgh");   // These characters ocr is looking for
+            engine.SetCharacterBlacklist("abc");        // These characters ocr is not looking for
+            // Now ocr should be only finding characters 'defgh'
+        };
+
+        // Recognize image 
+        var result = await Tesseract.RecognizeTextAsync(path);
+
+        // For this example I reset engine configuration, because same Object is used in other examples
+        Tesseract.EngineConfiguration = null;
+
+        // Show output (Not important)
+        ShowOutput("FromPath, Configured", result);
+
     }
+
 
     private async void DEMO_GetVersion(object sender, EventArgs e)
     {
         string version = Tesseract.TryGetTesseractLibVersion() ?? "Failed";
         await DisplayAlert("Tesseract version", version, "OK");
     }
+
 
     // Not important for package 
 
@@ -99,7 +116,19 @@ public partial class MainPage : ContentPage
         return pickResult?.FullPath;
     }
 
-
+    private void ShowOutput(string imageMode, RecognizionResult result)
+    {
+        // Show output (Not important)
+        fileModeLabel.Text = $"File mode: {imageMode}";
+        if (result.NotSuccess())
+        {
+            confidenceLabel.Text = $"Confidence: -1";
+            resultLabel.Text = $"Recognizion failed: {result.Status}";
+            return;
+        }
+        confidenceLabel.Text = $"Confidence: {result.Confidence}";
+        resultLabel.Text = result.RecognisedText;
+    }
 
  
 }

--- a/TesseractOcrMauiTestApp/MainPage.xaml.cs
+++ b/TesseractOcrMauiTestApp/MainPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using TesseractOcrMaui;
-using TesseractOcrMaui.Extensions;
+using TesseractOcrMaui.Results;
 #nullable enable
 namespace TesseractOcrMauiTestApp;
 
@@ -94,6 +94,12 @@ public partial class MainPage : ContentPage
         return pickResult?.FullPath;
     }
 
-    
+
+
+    private async void DEMO_GetVersion(object sender, EventArgs e)
+    {
+        string version = Tesseract.TryGetTesseractLibVersion() ?? "Failed";
+        await DisplayAlert("Tesseract version", version, "ok");
+    }
 }
 

--- a/TesseractOcrMauiTestApp/MainPage.xaml.cs
+++ b/TesseractOcrMauiTestApp/MainPage.xaml.cs
@@ -76,7 +76,12 @@ public partial class MainPage : ContentPage
         resultLabel.Text = result.RecognisedText;
     }
 
-    
+    private async void DEMO_GetVersion(object sender, EventArgs e)
+    {
+        string version = Tesseract.TryGetTesseractLibVersion() ?? "Failed";
+        await DisplayAlert("Tesseract version", version, "OK");
+    }
+
     // Not important for package 
 
     private static async Task<string?> GetUserSelectedPath()
@@ -96,10 +101,6 @@ public partial class MainPage : ContentPage
 
 
 
-    private async void DEMO_GetVersion(object sender, EventArgs e)
-    {
-        string version = Tesseract.TryGetTesseractLibVersion() ?? "Failed";
-        await DisplayAlert("Tesseract version", version, "ok");
-    }
+ 
 }
 


### PR DESCRIPTION
# Add TessEngine configuration to ITesseract 
## Fixes issue #16 
- TessEngine can now be configured with EngineConfiguration
``` cs
Action<ITessEngineConfigurable>? TesseractOcrMaui.ITesseract.EngineConfiguration { set; }
```

## Improved code quality 
- Better information in result from known issue #17 with KnownIssueException

## Updated examples in Mainpage.xaml.cs
- Added example of engine configuration action
``` cs
private async void DEMO_Recognize_AsConfigured(object sender, EventArgs e)
{
    // Select image (Not important)
    var path = await GetUserSelectedPath();
    if (path is null)
    {
        return;
    }

    Tesseract.EngineConfiguration = (engine) =>
    {
        // Engine uses DefaultSegmentationMode, if no other is passed as method parameter.
        // If ITesseract is injected to page, this is only way of setting PageSegmentationMode.
        // PageSegmentationMode defines how ocr tries to look for text, for example singe character or single word.
        // By default uses PageSegmentationMode.Auto.
        engine.DefaultSegmentationMode = TesseractOcrMaui.Enums.PageSegmentationMode.SingleLine;
        
        engine.SetCharacterWhitelist("abcdefgh");   // These characters ocr is looking for
        engine.SetCharacterBlacklist("abc");        // These characters ocr is not looking for
        // Now ocr should be only finding characters 'defgh'
    };

    // Recognize image 
    var result = await Tesseract.RecognizeTextAsync(path);

    // For this example I reset engine configuration, because same Object is used in other examples
    Tesseract.EngineConfiguration = null;

    // Show output (Not important)
    ShowOutput("FromPath, Configured", result);

}
```